### PR TITLE
support variable property names

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -146,5 +146,14 @@ module.exports = {
 			unresolved: 'warn'
 		},
 		warnings: 1
-	}
+	},
+	'properties': {
+		message: 'supports variable property names',
+		source: 'property.css',
+		expect: 'property.expect.css',
+		result: 'property.result.css',
+		processOptions: {
+			syntax: require('postcss-scss')
+		}
+	},
 };

--- a/src/lib/transform-decl.js
+++ b/src/lib/transform-decl.js
@@ -7,6 +7,7 @@ export default function transformDecl(decl, opts) {
 	// update the declaration value with its variables replaced by their corresponding values
 	decl.value = getReplacedString(decl.value, decl, opts);
 
+
 	// if the declaration is a variable declaration
 	if (isVariableDeclaration(decl)) {
 		// set the variable on the parent of the declaration
@@ -14,6 +15,8 @@ export default function transformDecl(decl, opts) {
 
 		// remove the declaration
 		decl.remove();
+	} else {
+		decl.prop = getReplacedString(decl.prop, decl, opts);
 	}
 }
 

--- a/test/property.css
+++ b/test/property.css
@@ -1,0 +1,18 @@
+$test-var-1: foo;
+$test-var-2: bar;
+$test-var-3: (foo, bar, baz);
+$test-var-4: custom-property;
+$test-var-5: black;
+
+--$(test-var-1)-replacement: "test-1";
+--$(test-var-1)-replacement2: $test-var-2;
+--$(test-var-1)-$(test-var-2): $test-var-1;
+
+@each $i in $test-var-3 {
+	--each-$(i): $i;
+}
+
+.class {
+    --$(test-var-4): $test-var-5;
+    color: var(--$(test-var-4))
+}

--- a/test/property.expect.css
+++ b/test/property.expect.css
@@ -1,0 +1,14 @@
+--foo-replacement: "test-1";
+--foo-replacement2: bar;
+--foo-bar: foo;
+
+--each-foo: foo;
+
+--each-bar: bar;
+
+--each-baz: baz;
+
+.class {
+    --custom-property: black;
+    color: var(--custom-property)
+}


### PR DESCRIPTION
Fixes #97. Allows the use of variable in declaration property names.

Example:
```css
$name: custom-property;
$value: black;

.class {
    --$(name): $value;
    color: var(--$(name))
}
```

results in 

```css
.class {
    --custom-property: black;
    color: var(--custom-property)
}
```